### PR TITLE
Fix TypeScript issues

### DIFF
--- a/src/components/ControlsPanel/ControlsPanel.tsx
+++ b/src/components/ControlsPanel/ControlsPanel.tsx
@@ -21,6 +21,13 @@ const KEY_OPTIONS = [
 const MODE_OPTIONS = ["major", "minor"] as const;
 const BAR_OPTIONS = [4, 8, 16] as const;
 
+function findKeyOption(
+  value: string,
+  fallback: (typeof KEY_OPTIONS)[number],
+): (typeof KEY_OPTIONS)[number] {
+  return KEY_OPTIONS.find((option) => option === value) ?? fallback;
+}
+
 export function ControlsPanel() {
   const settings = useAppStore((state) => state.settings);
   const updateSetting = useAppStore((state) => state.updateSetting);
@@ -41,7 +48,9 @@ export function ControlsPanel() {
           <span className="controls__label">Key</span>
           <select
             value={settings.key}
-            onChange={(event) => updateSetting("key", event.target.value)}
+            onChange={(event) =>
+              updateSetting("key", findKeyOption(event.target.value, settings.key))
+            }
           >
             {KEY_OPTIONS.map((option) => (
               <option key={option} value={option}>

--- a/tests/sequence.spec.ts
+++ b/tests/sequence.spec.ts
@@ -43,7 +43,7 @@ describe("sequence generation", () => {
     parts.forEach((part) => {
       const events = sequence.events.filter((event) => event.part === part);
       const sum = events.reduce((acc, event) => acc + event.durSteps, 0);
-      const expectedActive = sequence.generated[part].reduce((acc, value) => {
+      const expectedActive = sequence.generated[part].reduce<number>((acc, value) => {
         return acc + (value === null ? 0 : STEP_SIZES[part]);
       }, 0);
       expect(sum).toBe(expectedActive);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import path from "node:path";
 


### PR DESCRIPTION
## Summary
- ensure the controls panel only updates the key setting with valid options so TypeScript treats selections as KeyName values
- fix the sequence generation test accumulator typing to stay strictly numeric during reduction
- switch the Vite configuration to use Vitest's defineConfig helper so the test field is typed correctly

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d161aed8ac8333971c89c128bcd6b9