### PR TITLE
Fix SCSS mixin variable imports

### DIFF
--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -1,3 +1,5 @@
+@use "./variables" as *;
+
 @mixin card {
   background: linear-gradient(145deg, rgba(255, 255, 255, 0.04), rgba(0, 0, 0, 0.2));
   border-radius: $radius-lg;


### PR DESCRIPTION
## Summary
- import the shared variables module inside the SCSS mixins file so variable references resolve during Sass compilation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d16462f1f0833397103ea08d8f6f51