### PR TITLE
Fix asset paths for GitHub Pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: "./",
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- set Vite's base path to a relative value so built assets resolve correctly on GitHub Pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1820eb88c83338d99b2a2d80e4097