### PR TITLE
Add selectable synth styles to mixer

### DIFF
--- a/src/components/Mixer/Mixer.scss
+++ b/src/components/Mixer/Mixer.scss
@@ -24,6 +24,79 @@
   font-size: 0.85rem;
 }
 
+.mixer__styles {
+  border: 1px solid $color-border;
+  border-radius: $radius-md;
+  padding: $spacing-sm;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-sm;
+  background: $color-surface-alt;
+  margin: 0;
+}
+
+.mixer__styles legend {
+  margin: 0;
+  padding: 0 $spacing-xs;
+  @include label;
+}
+
+.mixer__style-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-sm;
+}
+
+.mixer__style {
+  display: flex;
+  align-items: flex-start;
+  gap: $spacing-sm;
+  padding: 0.5rem 0.75rem;
+  border-radius: $radius-md;
+  border: 1px solid $color-border;
+  background: rgba(255, 255, 255, 0.04);
+  cursor: pointer;
+  flex: 1 1 180px;
+  position: relative;
+}
+
+.mixer__style:focus-within {
+  outline: 2px solid rgba(255, 255, 255, 0.3);
+  outline-offset: 2px;
+}
+
+.mixer__style input {
+  margin-top: 0.2rem;
+}
+
+.mixer__style-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.mixer__style-name {
+  font-weight: 600;
+}
+
+.mixer__style-description {
+  font-size: 0.75rem;
+  color: $color-text-muted;
+  line-height: 1.2;
+}
+
+.mixer__style input:checked + .mixer__style-body {
+  color: $color-text;
+}
+
+.mixer__style input:checked + .mixer__style-body .mixer__style-name {
+  color: inherit;
+}
+
+.mixer__style input:checked + .mixer__style-body .mixer__style-description {
+  color: $color-text-muted;
+}
+
 .mixer__sliders {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));

--- a/src/components/Mixer/Mixer.tsx
+++ b/src/components/Mixer/Mixer.tsx
@@ -1,8 +1,31 @@
 import type { ChangeEvent } from "react";
 
+import type { Settings } from "@theory/notes";
 import { useAppStore } from "@store/useAppStore";
 
 import "./Mixer.scss";
+
+const synthStyleOptions: {
+  value: Settings["synthStyle"];
+  label: string;
+  description: string;
+}[] = [
+  {
+    value: "modern",
+    label: "Modern",
+    description: "Punchy saw and square voices",
+  },
+  {
+    value: "chiptune",
+    label: "Chiptune",
+    description: "Crunchy 8-bit inspired tones",
+  },
+  {
+    value: "ambient",
+    label: "Ambient",
+    description: "Soft pads with slow, airy envelopes",
+  },
+];
 
 export function Mixer() {
   const settings = useAppStore((state) => state.settings);
@@ -45,6 +68,30 @@ export function Mixer() {
           <span>Nice Mode</span>
         </label>
       </div>
+      <fieldset className="mixer__styles">
+        <legend>Synth Style</legend>
+        <div className="mixer__style-options">
+          {synthStyleOptions.map((option) => {
+            const id = `synth-style-${option.value}`;
+            return (
+              <label key={option.value} className="mixer__style" htmlFor={id}>
+                <input
+                  id={id}
+                  type="radio"
+                  name="synth-style"
+                  value={option.value}
+                  checked={settings.synthStyle === option.value}
+                  onChange={() => updateSetting("synthStyle", option.value)}
+                />
+                <div className="mixer__style-body">
+                  <span className="mixer__style-name">{option.label}</span>
+                  <span className="mixer__style-description">{option.description}</span>
+                </div>
+              </label>
+            );
+          })}
+        </div>
+      </fieldset>
       <div className="mixer__sliders">
         <label className="mixer__field">
           <span className="mixer__label">Filter Cutoff</span>

--- a/src/engine/scheduler.ts
+++ b/src/engine/scheduler.ts
@@ -53,7 +53,7 @@ export function createScheduler(context: AudioContext, synth: Synth): Scheduler 
       if (time > horizon) {
         break;
       }
-      synth.playDrums(absoluteStep % loopSteps, time);
+      synth.playDrums(absoluteStep % loopSteps, time, settings);
       state.nextDrumStep += 1;
     }
 

--- a/src/engine/synth.ts
+++ b/src/engine/synth.ts
@@ -1,25 +1,90 @@
 import type { Mixer } from "./mixer";
-import type { NoteEvent, PartName, Settings } from "@theory/notes";
+import type { NoteEvent, PartName, Settings, SynthStyle } from "@theory/notes";
 
-const DECAY_TIMES: Record<PartName, number> = {
-  bass: 0.35,
-  arp: 0.25,
-  lead: 0.5,
-};
+interface VoiceConfig {
+  wave: OscillatorType;
+  attack: number;
+  decay: number;
+  sustain: number;
+  release: number;
+}
 
-const BASE_WAVES: Record<PartName, OscillatorType> = {
-  bass: "sawtooth",
-  arp: "square",
-  lead: "sawtooth",
+interface DrumToneConfig {
+  wave: OscillatorType;
+  frequency: number;
+  duration: number;
+  level: number;
+}
+
+interface KickConfig {
+  wave: OscillatorType;
+  startFreq: number;
+  endFreq: number;
+  decay: number;
+  level: number;
+}
+
+interface DrumConfig {
+  kick: KickConfig;
+  snare: DrumToneConfig;
+  hat: DrumToneConfig;
+}
+
+interface SynthStyleConfig {
+  voices: Record<PartName, VoiceConfig>;
+  drums: DrumConfig;
+}
+
+const SYNTH_STYLE_CONFIG: Record<SynthStyle, SynthStyleConfig> = {
+  modern: {
+    voices: {
+      bass: { wave: "sawtooth", attack: 0.01, decay: 0.35, sustain: 0.6, release: 0.2 },
+      arp: { wave: "square", attack: 0.005, decay: 0.25, sustain: 0.4, release: 0.15 },
+      lead: { wave: "sawtooth", attack: 0.01, decay: 0.4, sustain: 0.45, release: 0.25 },
+    },
+    drums: {
+      kick: { wave: "sine", startFreq: 120, endFreq: 40, decay: 0.5, level: 1 },
+      snare: { wave: "square", frequency: 200, duration: 0.2, level: 0.4 },
+      hat: { wave: "square", frequency: 800, duration: 0.05, level: 0.3 },
+    },
+  },
+  chiptune: {
+    voices: {
+      bass: { wave: "square", attack: 0.001, decay: 0.08, sustain: 0.5, release: 0.08 },
+      arp: { wave: "square", attack: 0.001, decay: 0.06, sustain: 0.25, release: 0.05 },
+      lead: { wave: "square", attack: 0.001, decay: 0.07, sustain: 0.3, release: 0.06 },
+    },
+    drums: {
+      kick: { wave: "square", startFreq: 160, endFreq: 60, decay: 0.28, level: 0.9 },
+      snare: { wave: "square", frequency: 450, duration: 0.12, level: 0.3 },
+      hat: { wave: "square", frequency: 1400, duration: 0.04, level: 0.25 },
+    },
+  },
+  ambient: {
+    voices: {
+      bass: { wave: "triangle", attack: 0.04, decay: 0.5, sustain: 0.7, release: 0.6 },
+      arp: { wave: "sine", attack: 0.12, decay: 0.6, sustain: 0.75, release: 0.7 },
+      lead: { wave: "sine", attack: 0.15, decay: 0.7, sustain: 0.8, release: 0.8 },
+    },
+    drums: {
+      kick: { wave: "sine", startFreq: 90, endFreq: 40, decay: 0.7, level: 0.9 },
+      snare: { wave: "triangle", frequency: 180, duration: 0.35, level: 0.28 },
+      hat: { wave: "sine", frequency: 600, duration: 0.08, level: 0.22 },
+    },
+  },
 };
 
 function frequencyFromMidi(midi: number): number {
   return 440 * 2 ** ((midi - 69) / 12);
 }
 
+function resolveStyle(settings: Settings): SynthStyleConfig {
+  return SYNTH_STYLE_CONFIG[settings.synthStyle] ?? SYNTH_STYLE_CONFIG.modern;
+}
+
 export interface Synth {
   play(event: NoteEvent, time: number, settings: Settings): void;
-  playDrums(step: number, time: number): void;
+  playDrums(step: number, time: number, settings: Settings): void;
   stopAll(): void;
 }
 
@@ -30,16 +95,43 @@ export function createSynth(context: AudioContext, mixer: Mixer): Synth {
   drumGain.connect(mixer.input);
 
   function applyNiceMode(part: PartName, settings: Settings): OscillatorType {
-    if (!settings.nice) {
-      return BASE_WAVES[part];
+    if (settings.nice) {
+      return part === "bass" ? "triangle" : "sine";
     }
-    return part === "bass" ? "triangle" : "sine";
+    const style = resolveStyle(settings);
+    return style.voices[part].wave;
+  }
+
+  function scheduleVoice(
+    voice: VoiceConfig,
+    gain: GainNode,
+    time: number,
+    durationSeconds: number,
+  ) {
+    const attackEnd = time + voice.attack;
+    const decayEnd = attackEnd + voice.decay;
+    const sustainStart = Math.max(decayEnd, time);
+    const releaseStart = Math.max(time + durationSeconds, sustainStart);
+    const endTime = releaseStart + voice.release;
+
+    gain.gain.cancelScheduledValues(time);
+    gain.gain.setValueAtTime(0, time);
+    gain.gain.linearRampToValueAtTime(1, attackEnd);
+    gain.gain.linearRampToValueAtTime(voice.sustain, sustainStart);
+    gain.gain.setValueAtTime(voice.sustain, releaseStart);
+    gain.gain.linearRampToValueAtTime(0, endTime);
+
+    return endTime;
   }
 
   function play(event: NoteEvent, time: number, settings: Settings) {
     if (event.midi === null) {
       return;
     }
+
+    const style = resolveStyle(settings);
+    const voice = style.voices[event.part];
+
     const osc = context.createOscillator();
     osc.type = applyNiceMode(event.part, settings);
     osc.frequency.value = frequencyFromMidi(event.midi);
@@ -47,19 +139,8 @@ export function createSynth(context: AudioContext, mixer: Mixer): Synth {
     const gain = context.createGain();
     gain.gain.value = 0;
 
-    const attack = 0.01;
-    const decay = DECAY_TIMES[event.part];
-    const sustainLevel = event.part === "bass" ? 0.6 : 0.4;
-    const release = 0.2;
-
     const durationSeconds = (event.durSteps / 4) * (60 / settings.bpm);
-    const endTime = time + durationSeconds + release;
-
-    gain.gain.setValueAtTime(0, time);
-    gain.gain.linearRampToValueAtTime(1, time + attack);
-    gain.gain.linearRampToValueAtTime(sustainLevel, time + attack + decay);
-    gain.gain.setValueAtTime(sustainLevel, time + durationSeconds);
-    gain.gain.linearRampToValueAtTime(0, endTime);
+    const endTime = scheduleVoice(voice, gain, time, durationSeconds);
 
     osc.connect(gain);
     gain.connect(mixer.input);
@@ -69,47 +150,64 @@ export function createSynth(context: AudioContext, mixer: Mixer): Synth {
 
     activeNodes.push({ oscillator: osc, gain });
     osc.onended = () => {
-      gain.disconnect();
+      try {
+        gain.disconnect();
+        osc.disconnect();
+      } catch {
+        // noop
+      }
+      const index = activeNodes.findIndex((node) => node.oscillator === osc);
+      if (index >= 0) {
+        activeNodes.splice(index, 1);
+      }
     };
   }
 
-  function playNoiseBurst(time: number, duration: number, frequency: number) {
+  function playTone(time: number, config: DrumToneConfig) {
     const osc = context.createOscillator();
-    osc.type = "square";
-    osc.frequency.value = frequency;
+    osc.type = config.wave;
+    osc.frequency.value = config.frequency;
+
     const gain = context.createGain();
-    gain.gain.setValueAtTime(0.4, time);
-    gain.gain.exponentialRampToValueAtTime(0.001, time + duration);
+    gain.gain.setValueAtTime(config.level, time);
+    gain.gain.exponentialRampToValueAtTime(0.001, time + config.duration);
+
     osc.connect(gain);
     gain.connect(drumGain);
     osc.start(time);
-    osc.stop(time + duration);
+    osc.stop(time + config.duration);
   }
 
-  function playKick(time: number) {
+  function playKick(time: number, config: KickConfig) {
     const osc = context.createOscillator();
-    osc.type = "sine";
+    osc.type = config.wave;
+
     const gain = context.createGain();
-    gain.gain.setValueAtTime(1, time);
-    gain.gain.exponentialRampToValueAtTime(0.001, time + 0.5);
-    osc.frequency.setValueAtTime(120, time);
-    osc.frequency.exponentialRampToValueAtTime(40, time + 0.5);
+    gain.gain.setValueAtTime(config.level, time);
+    gain.gain.exponentialRampToValueAtTime(0.001, time + config.decay);
+
+    osc.frequency.setValueAtTime(config.startFreq, time);
+    osc.frequency.exponentialRampToValueAtTime(config.endFreq, time + config.decay);
+
     osc.connect(gain);
     gain.connect(drumGain);
     osc.start(time);
-    osc.stop(time + 0.5);
+    osc.stop(time + config.decay);
   }
 
-  function playDrums(step: number, time: number) {
+  function playDrums(step: number, time: number, settings: Settings) {
+    const style = resolveStyle(settings);
+    const { drums } = style;
     const beatPosition = step % 16;
+
     if (beatPosition === 0) {
-      playKick(time);
+      playKick(time, drums.kick);
     }
     if (beatPosition === 8) {
-      playNoiseBurst(time, 0.2, 200);
+      playTone(time, drums.snare);
     }
     if (beatPosition % 4 === 0) {
-      playNoiseBurst(time, 0.05, 800);
+      playTone(time, drums.hat);
     }
   }
 

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -76,6 +76,7 @@ const DEFAULT_SETTINGS: Settings = {
   autoGain: true,
   nice: false,
   lockNotes: false,
+  synthStyle: "modern",
 };
 
 const INITIAL_PROGRESSION = buildProgression(
@@ -307,8 +308,9 @@ export const useAppStore = create<AppState>((set, get) => ({
       arp: preset.userNotes.arp ?? preset.generatedNotes.arp,
       bass: preset.userNotes.bass ?? preset.generatedNotes.bass,
     };
+    const mergedSettings: Settings = { ...DEFAULT_SETTINGS, ...preset.settings };
     set({
-      settings: preset.settings,
+      settings: mergedSettings,
       progression: preset.progression,
       userNotes: cloneUserNotes(preset.userNotes),
       generatedNotes: cloneGeneratedNotes(preset.generatedNotes),

--- a/src/theory/notes.ts
+++ b/src/theory/notes.ts
@@ -17,6 +17,8 @@ export type KeyName =
   | "Bb"
   | "B";
 
+export type SynthStyle = "modern" | "chiptune" | "ambient";
+
 export interface Settings {
   key: KeyName;
   mode: Mode;
@@ -31,6 +33,7 @@ export interface Settings {
   autoGain: boolean;
   nice: boolean;
   lockNotes: boolean;
+  synthStyle: SynthStyle;
 }
 
 export interface Progression {

--- a/tests/presets.spec.ts
+++ b/tests/presets.spec.ts
@@ -25,6 +25,7 @@ const BASE_PRESET: Omit<PresetPayload, "name" | "createdAt"> = {
     autoGain: true,
     nice: false,
     lockNotes: false,
+    synthStyle: "modern",
   },
   progression: { bars: 4, degrees: [0, 4, 5, 3] },
   userNotes: { lead: null, arp: null, bass: null },

--- a/tests/scheduler.spec.ts
+++ b/tests/scheduler.spec.ts
@@ -39,6 +39,7 @@ describe("scheduler runtime", () => {
     autoGain: true,
     nice: false,
     lockNotes: false,
+    synthStyle: "modern",
   };
 
   const events: NoteEvent[] = [
@@ -72,7 +73,11 @@ describe("scheduler runtime", () => {
       expect.any(Number),
       expect.objectContaining({ bpm: 120 }),
     );
-    expect(synth.playDrums).toHaveBeenCalled();
+    expect(synth.playDrums).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.any(Number),
+      expect.objectContaining({ bpm: 120 }),
+    );
 
     synth.play.mockClear();
 

--- a/tests/sequence.spec.ts
+++ b/tests/sequence.spec.ts
@@ -18,6 +18,7 @@ const BASE_SETTINGS: Settings = {
   autoGain: true,
   nice: false,
   lockNotes: false,
+  synthStyle: "modern",
 };
 
 const EMPTY_USER_NOTES = { lead: null, arp: null, bass: null };

--- a/tests/store.spec.ts
+++ b/tests/store.spec.ts
@@ -11,24 +11,22 @@ const createMixerMock = vi.fn();
 const createSynthMock = vi.fn();
 const createSchedulerMock = vi.fn();
 const createVisualizerMock = vi.fn();
-const generateSequenceMock = vi.fn(
-  (settings: Settings, _progression: unknown, _userNotes: unknown) => {
-    const bars = settings.bars;
-    const lead = Array.from({ length: bars * 8 }, (_, index) =>
-      index % 3 === 2 ? null : 70 + index,
-    );
-    const arp = Array.from({ length: bars * 16 }, (_, index) => 60 + (index % 5));
-    const bass = Array.from({ length: bars * 4 }, () => 40);
-    const events: NoteEvent[] = [
-      { part: "lead", step: 0, durSteps: 2, midi: 70 },
-      { part: "bass", step: 0, durSteps: 4, midi: 40 },
-    ];
-    return {
-      generated: { lead, arp, bass } satisfies PartNoteMap,
-      events,
-    };
-  },
-);
+const generateSequenceMock = vi.fn((settings: Settings) => {
+  const bars = settings.bars;
+  const lead = Array.from({ length: bars * 8 }, (_, index) =>
+    index % 3 === 2 ? null : 70 + index,
+  );
+  const arp = Array.from({ length: bars * 16 }, (_, index) => 60 + (index % 5));
+  const bass = Array.from({ length: bars * 4 }, () => 40);
+  const events: NoteEvent[] = [
+    { part: "lead", step: 0, durSteps: 2, midi: 70 },
+    { part: "bass", step: 0, durSteps: 4, midi: 40 },
+  ];
+  return {
+    generated: { lead, arp, bass } satisfies PartNoteMap,
+    events,
+  };
+});
 
 vi.mock("@engine/audioContext", () => ({
   ensureAudioContext: ensureAudioContextMock,


### PR DESCRIPTION
## Summary
- add a synthStyle setting to the app store and preset payloads so users can choose between modern, chiptune, and ambient timbres
- update the mixer panel with radio controls and styling for selecting the synth style
- drive new synth-style aware envelopes and drum voices in the audio engine and pass the setting through the scheduler and tests

## Testing
- npm run lint
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d186663a548333a86e9013c16bb577