### PR TITLE
Prevent arp notes from dropping out of range

### DIFF
--- a/src/theory/notes.ts
+++ b/src/theory/notes.ts
@@ -218,29 +218,33 @@ export function closestMidiToTarget(
   preferredOctave: number,
 ): Midi {
   const base = midiForPitchClass(targetPc, preferredOctave);
-  let candidate = base;
-  let distance = Math.abs(candidate - reference);
+  const options: number[] = [base];
 
-  while (candidate < reference - 6) {
-    candidate += 12;
-  }
-  while (candidate > reference + 6) {
-    candidate -= 12;
+  for (let value = base + 12; value <= 127; value += 12) {
+    options.push(value);
   }
 
-  distance = Math.abs(candidate - reference);
-
-  const altUp = candidate + 12;
-  const altDown = candidate - 12;
-
-  if (Math.abs(altUp - reference) < distance) {
-    candidate = altUp;
-    distance = Math.abs(candidate - reference);
+  for (let value = base - 12; value >= 0; value -= 12) {
+    options.push(value);
   }
 
-  if (Math.abs(altDown - reference) < distance) {
-    candidate = altDown;
-  }
+  const candidate = options.reduce((best, current) => {
+    const bestDistance = Math.abs(best - reference);
+    const currentDistance = Math.abs(current - reference);
+
+    if (currentDistance < bestDistance) {
+      return current;
+    }
+
+    if (
+      currentDistance === bestDistance &&
+      Math.abs(current - base) < Math.abs(best - base)
+    ) {
+      return current;
+    }
+
+    return best;
+  }, base);
 
   return clampMidi(candidate);
 }

--- a/tests/theory.spec.ts
+++ b/tests/theory.spec.ts
@@ -47,5 +47,6 @@ describe("theory helpers", () => {
     expect(closestMidiToTarget(0, 60, 4)).toBe(60);
     expect(closestMidiToTarget(0, 73, 4)).toBe(72);
     expect(closestMidiToTarget(0, 47, 3)).toBe(48);
+    expect(closestMidiToTarget(7, 0, 4)).toBe(7);
   });
 });


### PR DESCRIPTION
## Summary
- update closestMidiToTarget to choose among in-range octave offsets and avoid wrapping to MIDI 0
- add regression test covering low-reference selection to keep arp notes from collapsing

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d18ac17a4c83338d06bcfb9404790f